### PR TITLE
react-intl upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+* Breaking Change
+  * Removed `mountContext` and `shallowContext`
+  * Updated `mockIntl` to match latest intl shape
+
 * Changed
   * Updated browserslist-config-terra dependency to @cerner/browerslist-config-terra v3
+  * Updated to utilize WrappingComponent instead of injecting context
 
 ## 3.4.0 - (June 9, 2020)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,8 +4,10 @@ Cerner Corporation
 - Cody Price [@dev-cprice]
 - Brett Jankord [@bjankord]
 - Dianna McGinn [@DMcginn]
+- Jaime Mackey [@jmsv6d]
 
 [@mjhenkes]: https://github.com/mjhenkes
 [@dev-cprice]: https://github.com/dev-cprice
 [@bjankord]: https://github.com/bjankord
 [@DMcginn]: https://github.com/DMcginn
+[@jmsv6d]: https://github.com/jmsv6d

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "jest": "^24.0.0",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
-    "react-intl": "^2.8.0"
+    "react-intl": "^5.10.6"
   },
   "peerDependencies": {
     "enzyme": "3.x",
     "react": "16.x",
-    "react-intl": ">= 2.7"
+    "react-intl": ">= 5.10.6"
   },
   "scripts": {
     "clean": "rm -rf node_modules",

--- a/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
+++ b/tests/jest/__snapshots__/enzyme-intl.test.jsx.snap
@@ -1,145 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mountContext with mount using FormattedMessage should match the snapshot 1`] = `
-<FormattedMessageSubject
-  foo="bar"
->
-  <div>
-    <FormattedMessage
-      id="TerraEnzymeIntl.helloWorld"
-      values={Object {}}
-    >
-      <span>
-        TerraEnzymeIntl.helloWorld
-      </span>
-    </FormattedMessage>
-    <FormattedMessage
-      id="TerraEnzymeIntl.buttonText"
-      values={Object {}}
-    >
-      <button
-        type="button"
-      >
-        TerraEnzymeIntl.buttonText
-      </button>
-    </FormattedMessage>
-    {
-  "foo": "bar"
-}
-  </div>
-</FormattedMessageSubject>
-`;
-
-exports[`mountContext with mount using contextTypes should match the snapshot 1`] = `
-<ContextTypesSubject
-  foo="bar"
->
-  <div>
-    TerraEnzymeIntl.helloWorld
-    <button
-      type="button"
-    >
-      TerraEnzymeIntl.buttonText
-    </button>
-    {
-  "foo": "bar"
-}
-  </div>
-</ContextTypesSubject>
-`;
-
-exports[`mountContext with mount using injectIntl should match the snapshot 1`] = `
-<InjectIntl(Component)
-  foo="bar"
->
-  <Component
-    foo="bar"
-    intl={
-      Object {
-        "defaultFormats": Object {},
-        "defaultLocale": "en",
-        "formatDate": [Function],
-        "formatHTMLMessage": [Function],
-        "formatMessage": [Function],
-        "formatNumber": [Function],
-        "formatPlural": [Function],
-        "formatRelative": [Function],
-        "formatTime": [Function],
-        "formats": Object {},
-        "formatters": Object {
-          "getDateTimeFormat": [Function],
-          "getMessageFormat": [Function],
-          "getNumberFormat": [Function],
-          "getPluralFormat": [Function],
-          "getRelativeFormat": [Function],
-        },
-        "locale": "en",
-        "messages": null,
-        "now": [Function],
-        "onError": [Function],
-        "textComponent": "span",
-        "timeZone": null,
-      }
-    }
-  >
-    <div>
-      TerraEnzymeIntl.helloWorld
-      <button
-        type="button"
-      >
-        TerraEnzymeIntl.buttonText
-      </button>
-      {
-  "foo": "bar"
-}
-    </div>
-  </Component>
-</InjectIntl(Component)>
-`;
-
 exports[`mountWithIntl using FormattedMessage should match the snapshot 1`] = `
 <FormattedMessageSubject
   foo="bar"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": null,
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": null,
-    }
-  }
 >
   <div>
     <FormattedMessage
       id="TerraEnzymeIntl.helloWorld"
-      values={Object {}}
     >
-      <span>
-        TerraEnzymeIntl.helloWorld
-      </span>
+      TerraEnzymeIntl.helloWorld
     </FormattedMessage>
     <FormattedMessage
       id="TerraEnzymeIntl.buttonText"
-      values={Object {}}
     >
       <button
         type="button"
@@ -148,107 +20,15 @@ exports[`mountWithIntl using FormattedMessage should match the snapshot 1`] = `
       </button>
     </FormattedMessage>
     {
-  "foo": "bar",
-  "intl": {
-    "locale": "en",
-    "messages": {},
-    "formats": {},
-    "timeZone": null,
-    "textComponent": "span",
-    "defaultLocale": "en",
-    "defaultFormats": {},
-    "formatters": {}
-  }
+  "foo": "bar"
 }
   </div>
 </FormattedMessageSubject>
 `;
 
-exports[`mountWithIntl using contextTypes should match the snapshot 1`] = `
-<ContextTypesSubject
-  foo="bar"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": null,
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": null,
-    }
-  }
->
-  <div>
-    TerraEnzymeIntl.helloWorld
-    <button
-      type="button"
-    >
-      TerraEnzymeIntl.buttonText
-    </button>
-    {
-  "foo": "bar",
-  "intl": {
-    "locale": "en",
-    "messages": {},
-    "formats": {},
-    "timeZone": null,
-    "textComponent": "span",
-    "defaultLocale": "en",
-    "defaultFormats": {},
-    "formatters": {}
-  }
-}
-  </div>
-</ContextTypesSubject>
-`;
-
 exports[`mountWithIntl using injectIntl should match the snapshot 1`] = `
-<InjectIntl(Component)
+<injectIntl(Component)
   foo="bar"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": null,
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": null,
-    }
-  }
 >
   <Component
     foo="bar"
@@ -256,27 +36,35 @@ exports[`mountWithIntl using injectIntl should match the snapshot 1`] = `
       Object {
         "defaultFormats": Object {},
         "defaultLocale": "en",
+        "defaultRichTextElements": undefined,
         "formatDate": [Function],
-        "formatHTMLMessage": [Function],
+        "formatDateTimeRange": [Function],
+        "formatDateToParts": [Function],
+        "formatDisplayName": [Function],
+        "formatList": [Function],
         "formatMessage": [Function],
         "formatNumber": [Function],
+        "formatNumberToParts": [Function],
         "formatPlural": [Function],
-        "formatRelative": [Function],
+        "formatRelativeTime": [Function],
         "formatTime": [Function],
+        "formatTimeToParts": [Function],
         "formats": Object {},
         "formatters": Object {
           "getDateTimeFormat": [Function],
+          "getDisplayNames": [Function],
+          "getListFormat": [Function],
           "getMessageFormat": [Function],
           "getNumberFormat": [Function],
-          "getPluralFormat": [Function],
-          "getRelativeFormat": [Function],
+          "getPluralRules": [Function],
+          "getRelativeTimeFormat": [Function],
         },
         "locale": "en",
         "messages": null,
-        "now": [Function],
         "onError": [Function],
-        "textComponent": "span",
-        "timeZone": null,
+        "textComponent": Symbol(react.fragment),
+        "timeZone": undefined,
+        "wrapRichTextChunksInFragment": undefined,
       }
     }
   >
@@ -292,36 +80,10 @@ exports[`mountWithIntl using injectIntl should match the snapshot 1`] = `
 }
     </div>
   </Component>
-</InjectIntl(Component)>
+</injectIntl(Component)>
 `;
 
 exports[`renderWithIntl using FormattedMessage should match the snapshot 1`] = `
-<div>
-  <span>
-    TerraEnzymeIntl.helloWorld
-  </span>
-  <button
-    type="button"
-  >
-    TerraEnzymeIntl.buttonText
-  </button>
-  {
-  "foo": "bar",
-  "intl": {
-    "locale": "en",
-    "messages": {},
-    "formats": {},
-    "timeZone": null,
-    "textComponent": "span",
-    "defaultLocale": "en",
-    "defaultFormats": {},
-    "formatters": {}
-  }
-}
-</div>
-`;
-
-exports[`renderWithIntl using contextTypes should match the snapshot 1`] = `
 <div>
   TerraEnzymeIntl.helloWorld
   <button
@@ -330,17 +92,7 @@ exports[`renderWithIntl using contextTypes should match the snapshot 1`] = `
     TerraEnzymeIntl.buttonText
   </button>
   {
-  "foo": "bar",
-  "intl": {
-    "locale": "en",
-    "messages": {},
-    "formats": {},
-    "timeZone": null,
-    "textComponent": "span",
-    "defaultLocale": "en",
-    "defaultFormats": {},
-    "formatters": {}
-  }
+  "foo": "bar"
 }
 </div>
 `;
@@ -359,119 +111,18 @@ exports[`renderWithIntl using injectIntl should match the snapshot 1`] = `
 </div>
 `;
 
-exports[`shallowContext with shallow using FormattedMessage should match the snapshot 1`] = `
-<div>
-  <FormattedMessage
-    id="TerraEnzymeIntl.helloWorld"
-    values={Object {}}
-  />
-  <FormattedMessage
-    id="TerraEnzymeIntl.buttonText"
-    values={Object {}}
-  >
-    <Component />
-  </FormattedMessage>
-  {
-  "foo": "bar"
-}
-</div>
-`;
-
-exports[`shallowContext with shallow using contextTypes should match the snapshot 1`] = `
-<div>
-  TerraEnzymeIntl.helloWorld
-  <button
-    type="button"
-  >
-    TerraEnzymeIntl.buttonText
-  </button>
-  {
-  "foo": "bar"
-}
-</div>
-`;
-
-exports[`shallowContext with shallow using injectIntl should match the snapshot 1`] = `
-<Component
-  foo="bar"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": null,
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": null,
-    }
-  }
-/>
-`;
-
 exports[`shallowWithIntl using FormattedMessage should match the snapshot 1`] = `
 <div>
   <FormattedMessage
     id="TerraEnzymeIntl.helloWorld"
-    values={Object {}}
   />
   <FormattedMessage
     id="TerraEnzymeIntl.buttonText"
-    values={Object {}}
   >
     <Component />
   </FormattedMessage>
   {
-  "foo": "bar",
-  "intl": {
-    "locale": "en",
-    "messages": {},
-    "formats": {},
-    "timeZone": null,
-    "textComponent": "span",
-    "defaultLocale": "en",
-    "defaultFormats": {},
-    "formatters": {}
-  }
-}
-</div>
-`;
-
-exports[`shallowWithIntl using contextTypes should match the snapshot 1`] = `
-<div>
-  TerraEnzymeIntl.helloWorld
-  <button
-    type="button"
-  >
-    TerraEnzymeIntl.buttonText
-  </button>
-  {
-  "foo": "bar",
-  "intl": {
-    "locale": "en",
-    "messages": {},
-    "formats": {},
-    "timeZone": null,
-    "textComponent": "span",
-    "defaultLocale": "en",
-    "defaultFormats": {},
-    "formatters": {}
-  }
+  "foo": "bar"
 }
 </div>
 `;
@@ -483,27 +134,35 @@ exports[`shallowWithIntl using injectIntl should match the snapshot 1`] = `
     Object {
       "defaultFormats": Object {},
       "defaultLocale": "en",
+      "defaultRichTextElements": undefined,
       "formatDate": [Function],
-      "formatHTMLMessage": [Function],
+      "formatDateTimeRange": [Function],
+      "formatDateToParts": [Function],
+      "formatDisplayName": [Function],
+      "formatList": [Function],
       "formatMessage": [Function],
       "formatNumber": [Function],
+      "formatNumberToParts": [Function],
       "formatPlural": [Function],
-      "formatRelative": [Function],
+      "formatRelativeTime": [Function],
       "formatTime": [Function],
+      "formatTimeToParts": [Function],
       "formats": Object {},
       "formatters": Object {
         "getDateTimeFormat": [Function],
+        "getDisplayNames": [Function],
+        "getListFormat": [Function],
         "getMessageFormat": [Function],
         "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
+        "getPluralRules": [Function],
+        "getRelativeTimeFormat": [Function],
       },
       "locale": "en",
       "messages": null,
-      "now": [Function],
       "onError": [Function],
-      "textComponent": "span",
-      "timeZone": null,
+      "textComponent": Symbol(react.fragment),
+      "timeZone": undefined,
+      "wrapRichTextChunksInFragment": undefined,
     }
   }
 />

--- a/tests/jest/enzyme-intl.test.jsx
+++ b/tests/jest/enzyme-intl.test.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import {
   shallowWithIntl,
   mountWithIntl,
   renderWithIntl,
   mockIntl,
-  shallowContext,
-  mountContext,
 } from '../../src';
 
 const prettyPrintProps = props => JSON.stringify(props, undefined, 2);
@@ -30,23 +27,6 @@ const InjectIntlSubject = injectIntl(({ intl, ...props }) => (
   </div>
 ));
 
-const ContextTypesSubject = (props, { intl }) => (
-  <div>
-    {intl.formatMessage({ id: 'TerraEnzymeIntl.helloWorld' })}
-    <button type="button">{intl.formatMessage({ id: 'TerraEnzymeIntl.buttonText' })}</button>
-    {prettyPrintProps(props)}
-  </div>
-);
-ContextTypesSubject.contextTypes = {
-  /* eslint-disable consistent-return */
-  intl: (context) => {
-    if (context.intl === undefined) {
-      return new Error('Component is internationalized, and must be wrapped in terra-base');
-    }
-  },
-  /* eslint-enable consistent-return */
-};
-
 describe('shallowWithIntl', () => {
   describe('using FormattedMessage', () => {
     const subject = <FormattedMessageSubject foo="bar" />;
@@ -59,16 +39,7 @@ describe('shallowWithIntl', () => {
 
   describe('using injectIntl', () => {
     const subject = <InjectIntlSubject foo="bar" />;
-    const wrapper = shallowWithIntl(subject);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  describe('using contextTypes', () => {
-    const subject = <ContextTypesSubject foo="bar" />;
-    const wrapper = shallowWithIntl(subject);
+    const wrapper = shallowWithIntl(subject).dive();
 
     it('should match the snapshot', () => {
       expect(wrapper).toMatchSnapshot();
@@ -88,15 +59,6 @@ describe('mountWithIntl', () => {
 
   describe('using injectIntl', () => {
     const subject = <InjectIntlSubject foo="bar" />;
-    const wrapper = mountWithIntl(subject);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  describe('using contextTypes', () => {
-    const subject = <ContextTypesSubject foo="bar" />;
     const wrapper = mountWithIntl(subject);
 
     it('should match the snapshot', () => {
@@ -123,15 +85,6 @@ describe('renderWithIntl', () => {
       expect(wrapper).toMatchSnapshot();
     });
   });
-
-  describe('using contextTypes', () => {
-    const subject = <ContextTypesSubject foo="bar" />;
-    const wrapper = renderWithIntl(subject);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
 });
 
 describe('mockIntl', () => {
@@ -141,64 +94,6 @@ describe('mockIntl', () => {
   describe('when used in a method expecting the react-intl intl object', () => {
     it('should match the expected output', () => {
       expect(subject(mockIntl)).toEqual(expected);
-    });
-  });
-});
-
-describe('shallowContext with shallow', () => {
-  describe('using FormattedMessage', () => {
-    const subject = <FormattedMessageSubject foo="bar" />;
-    const wrapper = shallow(subject, shallowContext);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  describe('using injectIntl', () => {
-    const subject = <InjectIntlSubject foo="bar" />;
-    const wrapper = shallow(subject, shallowContext);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  describe('using contextTypes', () => {
-    const subject = <ContextTypesSubject foo="bar" />;
-    const wrapper = shallow(subject, shallowContext);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-});
-
-describe('mountContext with mount', () => {
-  describe('using FormattedMessage', () => {
-    const subject = <FormattedMessageSubject foo="bar" />;
-    const wrapper = mount(subject, mountContext);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  describe('using injectIntl', () => {
-    const subject = <InjectIntlSubject foo="bar" />;
-    const wrapper = mount(subject, mountContext);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  describe('using contextTypes', () => {
-    const subject = <ContextTypesSubject foo="bar" />;
-    const wrapper = mount(subject, mountContext);
-
-    it('should match the snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Upgrading enzyme helpers to work with react-intl v5. Starting in react-intl v3, `getChildContext()` was no longer supported. The [testing strategy](https://formatjs.io/docs/guides/testing) recommended by `formatjs` is to utilize the `wrappingComponent` api. 
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #11 

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
